### PR TITLE
Fix GetHandleInformation for mipmapped 3d textures

### DIFF
--- a/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
+++ b/Ryujinx.Graphics.Gpu/Image/TextureGroup.cs
@@ -452,13 +452,13 @@ namespace Ryujinx.Graphics.Gpu.Image
                     index = handleIndex;
                     baseLevel = 0;
 
-                    int layerLevels = _levels;
+                    int levelLayers = _layers;
 
-                    while (handleIndex >= layerLevels)
+                    while (handleIndex >= levelLayers)
                     {
-                        handleIndex -= layerLevels;
+                        handleIndex -= levelLayers;
                         baseLevel++;
-                        layerLevels = Math.Max(layerLevels >> 1, 1);
+                        levelLayers = Math.Max(levelLayers >> 1, 1);
                     }
 
                     baseLayer = handleIndex;
@@ -492,13 +492,13 @@ namespace Ryujinx.Graphics.Gpu.Image
             {
                 int baseLevel = 0;
 
-                int layerLevels = _layers;
+                int levelLayers = _layers;
 
-                while (index >= layerLevels)
+                while (index >= levelLayers)
                 {
-                    index -= layerLevels;
+                    index -= levelLayers;
                     baseLevel++;
-                    layerLevels = Math.Max(layerLevels >> 1, 1);
+                    levelLayers = Math.Max(levelLayers >> 1, 1);
                 }
 
                 return (index, baseLevel);


### PR DESCRIPTION
Got this the wrong way round - was causing games to try synchronize mipmap levels of like 52 on a 3d texture with 6 levels. Also, corrected the variable name in the method that _was_ working.